### PR TITLE
Add remove_dashes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ optional arguments:
   --placeholder PLACEHOLDER
                         inserts TOC at the placeholder string instead of inserting it on top of the document
   --no_toc_header       suppresses the Table of Contents header
+  --remove_dashes       Removes dashes from generated slugs
   -v, --version         show program's version number and exit
 </pre>
 

--- a/markdown_toclify/__init__.py
+++ b/markdown_toclify/__init__.py
@@ -8,5 +8,5 @@ from .markdown_toclify import positioning_headlines
 from .markdown_toclify import slugify_headline
 from .markdown_toclify import remove_lines
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 

--- a/markdown_toclify/__init__.py
+++ b/markdown_toclify/__init__.py
@@ -5,7 +5,7 @@ from .markdown_toclify import markdown_toclify
 from .markdown_toclify import tag_and_collect
 from .markdown_toclify import create_toc
 from .markdown_toclify import positioning_headlines
-from .markdown_toclify import dashify_headline
+from .markdown_toclify import slugify_headline
 from .markdown_toclify import remove_lines
 
 __version__ = '0.1.7'

--- a/markdown_toclify/markdown_toclify.py
+++ b/markdown_toclify/markdown_toclify.py
@@ -25,7 +25,7 @@ import argparse
 import re
 
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'
 
 VALIDS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-&'
 

--- a/markdown_toclify/markdown_toclify.py
+++ b/markdown_toclify/markdown_toclify.py
@@ -52,7 +52,7 @@ def remove_lines(lines, remove=('[[back to top]', '<a class="mk-toclify"')):
     return out
 
 
-def dashify_headline(line):
+def slugify_headline(line, remove_dashes=False):
     """
     Takes a header line from a Markdown document and
     returns a tuple of the
@@ -76,14 +76,16 @@ def dashify_headline(line):
                              else '-' for c in replaced_slash])
 
     lowered = rem_nonvalids.lower()
-    dashified = re.sub(r'(-)\1+', r'\1', lowered)  # remove duplicate dashes
-    dashified = dashified.strip('-')  # strip dashes from start and end
+    slugified = re.sub(r'(-)\1+', r'\1', lowered)  # remove duplicate dashes
+    slugified = slugified.strip('-')  # strip dashes from start and end
 
     # exception '&' (double-dash in github)
-    dashified = dashified.replace('-&-', '--')
+    slugified = slugified.replace('-&-', '--')
 
-    return [stripped_wspace, dashified, level]
+    if remove_dashes:
+        slugified = slugified.replace('-','')
 
+    return [stripped_wspace, slugified, level]
 
 def tag_and_collect(lines, id_tag=True, back_links=False, exclude_h=None):
     """

--- a/markdown_toclify/markdown_toclify.py
+++ b/markdown_toclify/markdown_toclify.py
@@ -87,7 +87,8 @@ def slugify_headline(line, remove_dashes=False):
 
     return [stripped_wspace, slugified, level]
 
-def tag_and_collect(lines, id_tag=True, back_links=False, exclude_h=None):
+
+def tag_and_collect(lines, id_tag=True, back_links=False, exclude_h=None, remove_dashes=False):
     """
     Gets headlines from the markdown document and creates anchor tags.
 
@@ -141,14 +142,14 @@ def tag_and_collect(lines, id_tag=True, back_links=False, exclude_h=None):
                 continue
 
             saw_headline = True
-            dashified = dashify_headline(l)
+            slugified = slugify_headline(l, remove_dashes)
 
-            if not exclude_h or not dashified[-1] in exclude_h:
+            if not exclude_h or not slugified[-1] in exclude_h:
                 if id_tag:
                     id_tag = '<a class="mk-toclify" id="%s"></a>'\
-                              % (dashified[1])
+                              % (slugified[1])
                     out_contents.append(id_tag)
-                headlines.append(dashified)
+                headlines.append(slugified)
 
         out_contents.append(l)
         if back_links and saw_headline:

--- a/markdown_toclify/markdown_toclify.py
+++ b/markdown_toclify/markdown_toclify.py
@@ -376,6 +376,9 @@ def commandline():
     parser.add_argument('--placeholder',
                         type=str,
                         help='inserts TOC at the placeholder string instead of inserting it on top of the document')
+    parser.add_argument('--remove_dashes',
+                        action='store_true',
+                        help='Removes dashes from generated slugs')
     parser.add_argument('--no_toc_header',
                         action='store_true',
                         help='suppresses the Table of Contents header')
@@ -398,7 +401,8 @@ def commandline():
                             no_toc_header=args.no_toc_header,
                             spacer=args.spacer,
                             placeholder=args.placeholder,
-                            exclude_h=exclude_h)
+                            exclude_h=exclude_h,
+                            remove_dashes=args.remove_dashes)
 
     if not args.output:
         print(cont)

--- a/markdown_toclify/markdown_toclify.py
+++ b/markdown_toclify/markdown_toclify.py
@@ -254,7 +254,7 @@ def output_markdown(markdown_cont, output_file):
 def markdown_toclify(input_file, output_file=None, github=False,
                      back_to_top=False, nolink=False,
                      no_toc_header=False, spacer=0, placeholder=None,
-                     exclude_h=None):
+                     exclude_h=None, remove_dashes=False):
     """ Function to add table of contents to markdown files.
 
     Parameters
@@ -288,6 +288,9 @@ def markdown_toclify(input_file, output_file=None, github=False,
         Excludes header levels, e.g., if [2, 3], ignores header
         levels 2 and 3 in the TOC.
 
+      remove_dashes: bool (default: False)
+        Removes dashes from headline slugs
+
     Returns
     -----------
     cont: str
@@ -301,6 +304,7 @@ def markdown_toclify(input_file, output_file=None, github=False,
                                             id_tag=not github,
                                             back_links=back_to_top,
                                             exclude_h=exclude_h,
+                                            remove_dashes=remove_dashes
                                             )
 
     leftjustified_headlines = positioning_headlines(raw_headlines)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='markdown_toclify',
-      version='0.1.7',
+      version='0.1.8',
       description='A Python module to adda a Table of Contents with internal section-links to Markdown documents.',
       author='Sebastian Raschka',
       author_email='se.raschka@gmail.com',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -121,10 +121,14 @@ def test_remove_lines():
 
 
 
-def test_dashify_headline():
+def test_slugify_headline():
     in1 = '### some headline lvl3'
+    out1 = 'some-headline-lvl3'
+    out2 = 'someheadlinelvl3'
 
-    assert(mt.dashify_headline(in1) == ['some headline lvl3', 'some-headline-lvl3', 3])
+    assert(mt.slugify_headline(in1) == ['some headline lvl3', out1, 3])
+    assert(mt.slugify_headline(in1, False) == ['some headline lvl3', out1, 3])
+    assert(mt.slugify_headline(in1, True) == ['some headline lvl3', out2, 3])
 
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,16 +29,20 @@ def test_markdown_std():
            'more text'
            ]
     out24 = [['first headline', 'first-headline', 1]]
+    out24_1 = [['first headline', 'firstheadline', 1]]
     assert(mt.tag_and_collect(ex24, id_tag=False)[1] == out24)
+    assert(mt.tag_and_collect(ex24, id_tag=False, remove_dashes=True)[1] == out24_1)
 
-    # A space is required between the # characters and the header’s content:
+    # A space is required between the # characters and the header's content:
     ex25 = ['# first headline',
            'some text',
            '##no headline',
            'more text'
            ]
     out25 = [['first headline', 'first-headline', 1]]
+    out25_1 = [['first headline', 'firstheadline', 1]]
     assert(mt.tag_and_collect(ex25, id_tag=False)[1] == out25)
+    assert(mt.tag_and_collect(ex25, id_tag=False, remove_dashes=True)[1] == out25_1)
 
     # This is not a header, because the first # is escaped:
     ex26 = ['# first headline',
@@ -47,7 +51,9 @@ def test_markdown_std():
            'more text'
            ]
     out26 = [['first headline', 'first-headline', 1]]
+    out26_1 = [['first headline', 'firstheadline', 1]]
     assert(mt.tag_and_collect(ex26, id_tag=False)[1] == out26)
+    assert(mt.tag_and_collect(ex26, id_tag=False, remove_dashes=True)[1] == out26_1)
 
     # Leading and trailing blanks are ignored in parsing inline content:
     ex28 = ['#           first headline',
@@ -55,7 +61,9 @@ def test_markdown_std():
            'more text'
            ]
     out28 = [['first headline', 'first-headline', 1]]
+    out28_1 = [['first headline', 'firstheadline', 1]]
     assert(mt.tag_and_collect(ex28, id_tag=False)[1] == out28)
+    assert(mt.tag_and_collect(ex28, id_tag=False, remove_dashes=True)[1] == out28_1)
 
 
     # One to three spaces indentation are allowed:
@@ -65,7 +73,9 @@ def test_markdown_std():
            'more text'
            ]
     out29 = [['first headline', 'first-headline', 1]]
+    out29_1 = [['first headline', 'firstheadline', 1]]
     assert(mt.tag_and_collect(ex29, id_tag=False)[1] == out29)
+    assert(mt.tag_and_collect(ex29, id_tag=False, remove_dashes=True)[1] == out29_1)
 
     # A closing sequence of # characters is optional:
     ex32 = ['## first headline ##',
@@ -73,7 +83,9 @@ def test_markdown_std():
            'more text'
            ]
     out32 = [['first headline', 'first-headline', 2]]
+    out32_1 = [['first headline', 'firstheadline', 2]]
     assert(mt.tag_and_collect(ex32, id_tag=False)[1] == out32)
+    assert(mt.tag_and_collect(ex32, id_tag=False, remove_dashes=True)[1] == out32_1)
 
     # It need not be the same length as the opening sequence:
     ex33 = ['## first headline ####',
@@ -81,7 +93,9 @@ def test_markdown_std():
            'more text'
            ]
     out33 = [['first headline', 'first-headline', 2]]
+    out33_1 = [['first headline', 'firstheadline', 2]]
     assert(mt.tag_and_collect(ex33, id_tag=False)[1] == out33)
+    assert(mt.tag_and_collect(ex33, id_tag=False, remove_dashes=True)[1] == out33_1)
 
     #A sequence of # characters with a nonspace character following it
     # is not a closing sequence, but counts as part of the contents of the header:
@@ -101,7 +115,9 @@ def test_markdown_std():
            ]
     print(mt.tag_and_collect(ex35, id_tag=False)[1])
     out35 = [['first headline', 'first-headline', 1]]
+    out35_1 = [['first headline', 'firstheadline', 1]]
     assert(mt.tag_and_collect(ex35, id_tag=False)[1] == out35)
+    assert(mt.tag_and_collect(ex35, id_tag=False, remove_dashes=True)[1] == out35_1)
 
 
 


### PR DESCRIPTION
I use [Ghost](https://ghost.org/) as a blogging platform. I'm in the middle of a few post builds regarding [Ansible](https://www.ansible.com/), so I'm working with a ton of [Jinja](http://jinja.pocoo.org/) templates. It makes more sense to me to use a Python tool to build everything rather than trying to frankenstein a build process with Python and JavaScript. However, its anchor ids are devoid of symbols.

This package is perfect. It's small, it's quick, and it does exactly what I need. This PR adds a new option, `remove_dashes`, that strips all dashes from the generated slug. It's off by default, so existing configurations don't need any updates.